### PR TITLE
disallows underflows

### DIFF
--- a/src/CS50.php
+++ b/src/CS50.php
@@ -69,7 +69,8 @@
             if (preg_match("/^(\+|-)?\d+$/", $s))
             {
                 $n = intval($s);
-                if ($n !== PHP_INT_MAX)
+                // disallow under/overflows and PHP_INT_MAX
+                if (bccomp($n, $s) === 0 && $n !== PHP_INT_MAX)
                 {
                     return $n;
                 }

--- a/src/CS50.php
+++ b/src/CS50.php
@@ -42,7 +42,7 @@
             if (preg_match("/^(\+|-)?\d*(\.\d*)?$/", $s))
             {
                 $f = floatval($s);
-                if ($f !== INF)
+                if ($f !== -INF && $f !== INF)
                 {
                     return $f;
                 }


### PR DESCRIPTION
using `$n !== PHP_INT_MAX` doesn't disallow underflows. this fixes the problem
by using `bccomp` to disallow underflows (since we want to allow `PHP_INT_MIN`).
